### PR TITLE
Added bower.json to make available via Bower Package Manager

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,39 @@
+{
+  "name": "pure-sass",
+  "version": "0.0.5",
+  "homepage": "https://github.com/fourseven/pure-sass",
+  "authors": ["Mathew Hartley"],
+  "description": "Yahoo's Pure CSS library ported to SASS.",
+  "main": [
+    "app/assets/stylesheets/defaults.css.scss",
+    "app/assets/stylesheets/base.css.scss",
+    "app/assets/stylesheets/buttons.css.scss",
+    "app/assets/stylesheets/forms.css.scss",
+    "app/assets/stylesheets/grids.css.scss",
+    "app/assets/stylesheets/menus.css.scss",
+    "app/assets/stylesheets/tables.css.scss"
+  ],
+  "keywords": [
+    "yahoo",
+    "pure",
+    "sass",
+    "scss"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "lib",
+    "spec",
+    "vendor",
+    ".gitignore",
+    ".gitmodules",
+    ".ruby-version",
+    ".travis.yml",
+    "Gemfile",
+    "Guardfile",
+    "LICENSE.txt",
+    "README.md",
+    "Rakefile",
+    "pure-sass.gemspec"
+  ],
+  "dependencies": {}
+}


### PR DESCRIPTION
[Bower](http://bower.io/) has become fairly popular for managing front-end dependencies, so it'd be nice to be able to install it this way. I added the bower.json file and all you'd need to do afterward (once you have bower installed) is run the following:

```
bower register pure-sass git://github.com/fourseven/pure-sass.git
```
